### PR TITLE
update PCcontrib example to access the ggplot object in the list output

### DIFF
--- a/R/gr-PCA.R
+++ b/R/gr-PCA.R
@@ -506,7 +506,7 @@ boxplot.PCA <- function(x, fac=NULL, nax, ...){
 #' \dontrun{
 #' library(ggplot2)
 #' gg <- PCcontrib(bot.p, nax=1:8, sd.r=c(-5, -3, -2, -1, -0.5, 0, 0.5, 1, 2, 3, 5))
-#' gg + geom_polygon(fill="slategrey", col="black") + ggtitle("A nice title")
+#' gg$gg + geom_polygon(fill="slategrey", col="black") + ggtitle("A nice title")
 #' }
 #' @rdname PCcontrib
 #' @export


### PR DESCRIPTION
Because the current example gives an error in Momocs_1.2.9:

> gg <- PCcontrib(bot.p, nax=1:8, sd.r=c(-5, -3, -2, -1, -0.5, 0, 0.5, 1, 2, 3, 5))
> gg + geom_polygon(fill="slategrey", col="black") + ggtitle("A nice title")
Error in gg + geom_polygon(fill = "slategrey", col = "black") + ggtitle("A nice title") : 
  non-numeric argument to binary operator