### PR TITLE
update for dplyr 1.0.8

### DIFF
--- a/R/cl-handling.R
+++ b/R/cl-handling.R
@@ -1084,7 +1084,7 @@ rm_missing.default <- function(x, by){
   if (missing(by))
     filter(x, !apply(is.na(x$fac), 1, any))
   else
-    filter(x, !is.na(x$fac[, by]))
+    filter(x, !is.na(x$fac[[by]]))
 }
 
 #' Removes harmonics from Coe objects


### PR DESCRIPTION
We're about to release dplyr 1.0.8, and as part of running our rev dep checks, we've identified that the released version of this package would fail with: 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘Momocs-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: rm_missing
  > ### Title: Remove shapes with missing data in fac
  > ### Aliases: rm_missing
  > 
  > ### ** Examples
  > 
  > bot$fac$type[3] <- NA
  > bot$fac$fake[9] <- NA
  > 
  > bot %>% length()
  [1] 40
  > bot %>% rm_missing() %>% length
  [1] 38
  > bot %>% rm_missing("fake") %>% length()
  Error: Problem while computing `..1 = !is.na(x$fac[, by])`.
  ✖ Input `..1` must be a logical vector, not a logical[,1].
  Backtrace:
       ▆
    1. ├─bot %>% rm_missing("fake") %>% length()
    2. ├─Momocs::rm_missing(., "fake")
    3. ├─Momocs:::rm_missing.default(., "fake")
    4. │ ├─Momocs::filter(x, !is.na(x$fac[, by]))
    5. │ └─Momocs:::filter.Coo(x, !is.na(x$fac[, by]))
    6. │   ├─dplyr::filter(df, ...)
    7. │   └─dplyr:::filter.data.frame(df, ...)
    8. │     └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
    9. │       └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
   10. │         ├─base::withCallingHandlers(...)
   11. │         └─mask$eval_all_filter(dots, env_filter)
   12. ├─dplyr:::dplyr_internal_error(...)
   13. │ └─rlang::abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
   14. │   └─rlang:::signal_abort(cnd, .file)
   15. │     └─base::signalCondition(cnd)
   16. └─dplyr `<fn>`(`<dpl:::__>`)
  Execution halted

1 error x | 0 warnings ✓ | 0 notes ✓
````

This is because the `is.na()` in `rm_missing.default()` returns a matrix and those are no longer supported in `filter()`. 

This pull request fixes the problem, assuming you only mean one variable in `by`, which is what I understand reading the code. 
